### PR TITLE
Update consolidate script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
         "plotly.js-dist": "^2.29.0",
-        "react": "^18.2.0",
+        "react": "^18.3.1",
         "react-dom": "^18.2.0",
         "react-scripts": "^5.0.1",
         "react-syntax-highlighter": "^15.5.0",
@@ -15074,9 +15074,9 @@
       }
     },
     "node_modules/react": {
-      "version": "18.3.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.0.tgz",
-      "integrity": "sha512-RPutkJftSAldDibyrjuku7q11d3oy6wKOyPe5K1HA/HwwrXcEqBdHsLypkC2FFYjP7bPUa6gbzSBhw4sY2JcDg==",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "dependencies": {
         "loose-envify": "^1.1.0"
       },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
     "plotly.js-dist": "^2.29.0",
-    "react": "^18.2.0",
+    "react": "^18.3.1",
     "react-dom": "^18.2.0",
     "react-scripts": "^5.0.1",
     "react-syntax-highlighter": "^15.5.0",

--- a/python/consolidate_datasets.py
+++ b/python/consolidate_datasets.py
@@ -2,7 +2,6 @@ import boto3
 import pandas as pd
 import zarr
 import numpy as np
-import sys
 from argparse import ArgumentParser
 
 from spikeinterface.core import Templates

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -8,7 +8,7 @@ import "../styles/App.css";
 //const url = "http://localhost:8000/zarr_store.zarr";
 const url = "https://spikeinterface-template-database.s3.us-east-2.amazonaws.com/test_templates";
 
-const url = process.env.TEST_URL || "https://s3.amazonaws.com/my-bucket/templates";
+//const url = process.env.TEST_URL || "https://s3.amazonaws.com/my-bucket/templates";
 
 
 function App() {
@@ -20,7 +20,7 @@ function App() {
   const batchSize = 10;
   const [dataDictionary, setDataDictionary] = useState({});
 
-  const loadTempalteIndices = () => {
+  const loadTemplateIndices = () => {
     const nextIndex = templateIndices.length === 0 ? 0 : Math.max(...templateIndices) + 1;
     const newIndices = Array.from({ length: batchSize }, (_, i) => i + nextIndex);
 
@@ -82,7 +82,7 @@ function App() {
   };
 
   useEffect(() => {
-    loadTempalteIndices();
+    loadTemplateIndices();
     loadSessionData();
   }, []);
 
@@ -104,7 +104,7 @@ function App() {
         ))}
       </div>
       {hasMore && (
-        <button onClick={loadTempalteIndices} className="load-more-button">
+        <button onClick={loadTemplateIndices} className="load-more-button">
           Load More Templates
         </button>
       )}

--- a/src/components/CodeSnippet.js
+++ b/src/components/CodeSnippet.js
@@ -6,10 +6,12 @@ import { vs } from 'react-syntax-highlighter/dist/esm/styles/prism';
 function CodeSnippet({ selectedTemplates }) {
   const generatePythonCode = (selectedTemplates) => {
     const selectedUnitIndicesString = JSON.stringify([...selectedTemplates], null, 2);
-    return `from spikeinterface.hybrid import generate_recording_from_template_database
+    return `from spikeinterface.generation import get_templates_from_database, generate_hybrid_recording
 selected_unit_indices = ${selectedUnitIndicesString}
-durations = [1.0]  # Specify the duration for each template
-recording = generate_recording_from_template_database(selected_unit_indices, durations=durations)`;
+templates = get_templates_from_database(selected_unit_indices)
+
+# recording is an existing spikeinterface.BaseRecording
+recording_hybrid = get_templates_from_database(recording, templates=templates)`;
   };
 
   const pythonCode = generatePythonCode(selectedTemplates);


### PR DESCRIPTION
@h-mayorquin updated the consolidate script and pushed a new version of the `templates.csv`

One note:
In the script where we compute and push the templates, I recommend reading also the recording using the `read_ibl_recording` function in order to grab the metadata associated to the probe, which is lost in the NWB.
This can be used to set the proper probe model and serial number in the `probe` field of the Zarr file.

As an example:
![image](https://github.com/SpikeInterface/hybrid_template_library/assets/17097257/993782c3-fcb0-472d-b0b7-ef95aed9b097)
